### PR TITLE
Added info about seed behavior

### DIFF
--- a/ce/developer/create-auto-number-attributes.md
+++ b/ce/developer/create-auto-number-attributes.md
@@ -221,6 +221,9 @@ The **AutoNumberSeed** message has the following parameters:
 |AttributeName|string|The logical name of the attribute you want to set the seed on.|
 |Value|int|Next auto-number value for the attribute.|
 
+### Seed is not solution aware
+Note that setting the seed only changes the **current number value** for the specified attribute. It does not imply a common **start value** for the attribute. Thus the seed is not solution aware to be transported between environments. To set the starting number after a solution import, the `SetAutoNumberSeedRequest` must be called in the target environment.
+
 ### Examples
 The following samples set the seed to 10000 for an auto-number attribute named **new\_SerialNumber** for a custom entity named **new\_Widget**.
 

--- a/ce/developer/create-auto-number-attributes.md
+++ b/ce/developer/create-auto-number-attributes.md
@@ -221,8 +221,8 @@ The **AutoNumberSeed** message has the following parameters:
 |AttributeName|string|The logical name of the attribute you want to set the seed on.|
 |Value|int|Next auto-number value for the attribute.|
 
-### Seed is not solution aware
-Note that setting the seed only changes the **current number value** for the specified attribute. It does not imply a common **start value** for the attribute. Thus the seed is not solution aware to be transported between environments. To set the starting number after a solution import, the `SetAutoNumberSeedRequest` must be called in the target environment.
+> [!NOTE]
+> Setting the seed only changes the **current number value** for the specified attribute in the current environment. It does not imply a common **start value** for the attribute. The seed value is not included in a solution when installed in a different environments. To set the starting number after a solution import, use **SetAutoNumberSeed** message in the target environment.
 
 ### Examples
 The following samples set the seed to 10000 for an auto-number attribute named **new\_SerialNumber** for a custom entity named **new\_Widget**.


### PR DESCRIPTION
Since I have had a number of questions from users of Auto Number Manager for XrmToolBox about why the seed set in DEV is not respected when solution is imported to TEST/PROD, a clarification would be good to have here.