### PR TITLE
fix: Unstick heading from anchor

### DIFF
--- a/ce/unified-service-desk/configure-toolbars-application.md
+++ b/ce/unified-service-desk/configure-toolbars-application.md
@@ -30,6 +30,7 @@ search.app:
 You can configure toolbars in [!INCLUDE[pn_unified_service_desk](../includes/pn-unified-service-desk.md)] to create or manage buttons in an existing toolbar, or create new toolbars altogether. For an overview of toolbars, see [Toolbars in Unified Service Desk](../unified-service-desk/toolbars-unified-service-desk.md).  
   
 <a name="Create"></a>   
+
 ## Create a toolbar  
  Before creating a toolbar, ensure that there is a toolbar container hosted control already configured. For more information, see [Toolbar Container (Hosted Control)](../unified-service-desk/toolbar-container-hosted-control.md).  
   
@@ -82,6 +83,7 @@ You can configure toolbars in [!INCLUDE[pn_unified_service_desk](../includes/pn-
 16. Click **Save**. 
   
 <a name="EditToolbar"></a>   
+
 ## Add/remove button from existing toolbar  
   
 1. Sign in to [!INCLUDE[pn_microsoftcrm](../includes/pn-microsoftcrm.md)].  
@@ -101,6 +103,7 @@ You can configure toolbars in [!INCLUDE[pn_unified_service_desk](../includes/pn-
    3.  Click **Save** to save the changes.
 
 <a name="StylesToolbar"></a>   
+
 ## Styles in toolbar
 
 You can now customize the toolbar in [!INCLUDE[pn_unified_service_desk](../includes/pn-unified-service-desk.md)] using the custom styles field in the Toolbar configuration window.  The Custom Styles field supports Extensible Application Markup Language (XAML) that defines <xref:System.Windows.ResourceDictionary> of <xref:System.Windows.Style> and <xref:System.Windows.Media.Brush> resources.


### PR DESCRIPTION
Minor, but some syntax highlighters don't recognize the headings stuck to an anchor. It seems like GitHub was OK with it because of the trailing space after the anchor before