### PR TITLE
Updated Sample to remove casting

### DIFF
--- a/ce/snippets/csharp/CRMV8/quickstartcs/cs/simplifiedconnection.cs
+++ b/ce/snippets/csharp/CRMV8/quickstartcs/cs/simplifiedconnection.cs
@@ -54,11 +54,8 @@ namespace Microsoft.Crm.Sdk.Samples
             try
             {
                 // Connect to the CRM web service using a connection string.
-                CrmServiceClient conn = new Xrm.Tooling.Connector.CrmServiceClient(connectionString);
+                CrmServiceClient _orgService  = new Xrm.Tooling.Connector.CrmServiceClient(connectionString);
  
-                // Cast the proxy client to the IOrganizationService interface.
-                _orgService = (IOrganizationService)conn.OrganizationWebProxyClient != null ? (IOrganizationService)conn.OrganizationWebProxyClient : (IOrganizationService)conn.OrganizationServiceProxy;
-             
                 //Create any entity records this sample requires.
                 CreateRequiredRecords();
 


### PR DESCRIPTION
- Removed Casting of OrganizationServiceProxy
- Renamed variable from conn to _orgService 

_orgService = (IOrganizationService)conn.OrganizationWebProxyClient != null ? (IOrganizationService)conn.OrganizationWebProxyClient : (IOrganizationService)conn.OrganizationServiceProxy;

Casting OrganizationServiceProxy or OrganizationWebProxyClient  is not recommended.