### PR TITLE
Added entity name to EntityCollection constructor, this fixes issues …

### DIFF
--- a/ce/developer/virtual-entities/sample-generic-ve-plugin.md
+++ b/ce/developer/virtual-entities/sample-generic-ve-plugin.md
@@ -96,7 +96,7 @@ public class DropboxRetrieveMultiplePlugin : IPlugin
 
     public async Task<EntityCollection> SearchFile(DropboxClient dbx, SearchArg arg)
     {
-        EntityCollection ec = new EntityCollection();
+        EntityCollection ec = new EntityCollection { EntityName = "new_dropbox" };
         var list = await dbx.Files.SearchAsync(arg);
         foreach (var item in list.Matches)
         {


### PR DESCRIPTION
EntityCollections need to have an entity name set for being retrievable using the WebAPI.

Otherwise there will be errors that name is not allowed to be empty when accessing the virtual entities using WebAPI.

Related to #689 