### PR TITLE
Remove 'Customer Engagement' duplicate phrase

### DIFF
--- a/ce/developer/webapi/authenticate-web-api.md
+++ b/ce/developer/webapi/authenticate-web-api.md
@@ -49,7 +49,7 @@ private HttpClient getNewHttpClient(string userName,string password,string domai
 ```  
   
 ### With [!INCLUDE[pn_dynamics_crm_online](../../includes/pn-dynamics-crm-online.md)] or Internet-facing deployments  
- When you use the Web API for [!INCLUDE[pn_crm_online_shortest](../../includes/pn-crm-online-shortest.md)] Customer Engagement or an on-premises Internet-facing deployment (IFD) you must use OAuth as described in [Use OAuth to connect to Dynamics 365 for Customer Engagement web Services](../connect-customer-engagement-web-services-using-oauth.md).  
+ When you use the Web API for [!INCLUDE[pn_crm_online_shortest](../../includes/pn-crm-online-shortest.md)] or an on-premises Internet-facing deployment (IFD) you must use OAuth as described in [Use OAuth to connect to Dynamics 365 for Customer Engagement web Services](../connect-customer-engagement-web-services-using-oauth.md).  
   
  If you’re creating a single page application (SPA) using [!INCLUDE[pn_JavaScript](../../includes/pn-javascript.md)] you can use the adal.js library as described in [Use OAuth with Cross-Origin Resource Sharing  to connect a Single Page Application  to Dynamics 365 for Customer Engagement](../oauth-cross-origin-resource-sharing-connect-single-page-application.md).  
   


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22633878/52446667-56256e00-2b37-11e9-93f9-f7acd39a2c7f.png)

I'm not sure what kind of approach is a trend for now, but I assume that you'd like to take 'Customer Engagement' phrase from a file, not to use the "hardcoded" duplicate one.

So here are my two cents to make docs better 😁