### PR TITLE
Update to the applies to section

### DIFF
--- a/ce/admin/enable-use-comprehensive-auditing.md
+++ b/ce/admin/enable-use-comprehensive-auditing.md
@@ -10,6 +10,7 @@ ms.tgt_pltfrm:
 ms.topic: article
 applies_to: 
   - Dynamics 365 for Customer Engagement  (online)
+  This is not correct based on the requirments section 
   - Dynamics 365 for Customer Engagement  Version 9.x
 ms.assetid: 817fb922-355a-4d5c-9d93-a320be31c276
 caps.latest.revision: 1
@@ -35,6 +36,7 @@ Protecting data, preserving privacy, and complying with regulations such as the 
 This topic covers how you can set [!INCLUDE [pn-ms-dyn-365](../includes/pn-ms-dyn-365.md)] to audit a broad range of data processing activities and use the [Office 365 Security and Compliance Center](https://support.office.com/article/go-to-the-office-365-security-compliance-center-7e696a40-b86b-4a20-afcc-559218b7b1b8?ui=en-US&rs=en-US&ad=US) to review the data in activity reports.
 
 ## Requirements
+This cant be a requirment if it can be enealbed on on-premise deployments 
 - An Office 365 Enterprise [E3](https://products.office.com/business/office-365-enterprise-e3-business-software) or [E5](https://products.office.com/business/office-365-enterprise-e5-business-software) subscription is required to do Activity Logging.
 - For version 8.x, version 8.2.2.1310 or later is required.
 - Available for Production and not Sandbox instances.


### PR DESCRIPTION
On the doc there is an applies to Applies to Dynamics 365 for Customer Engagement apps version 9.x (on-premises).  Then in the requirements its says An Office 365 Enterprise E3 or E5 subscription is required to do Activity Logging.  Since there is no documentation that shows you can link the on-premise deployment with a O365 subscription these two lines contradict each other.  If there is a way to link these can that be added or the applies to section be modified to remove the on-premise mention.