### PR TITLE
Replaced with working example

### DIFF
--- a/ce/developer/customize-dev/define-ribbon-enable-rules.md
+++ b/ce/developer/customize-dev/define-ribbon-enable-rules.md
@@ -94,7 +94,7 @@ function EnableRule()
     const request = new XMLHttpRequest();
     request.open('GET', '/bar/foo');
 
-    return new Promise((resolve, reject) =>
+    return new Promise(function (resolve, reject)
     {
         request.onload = function (e)
         {

--- a/ce/sales-enterprise/recalculateprice-action.md
+++ b/ce/sales-enterprise/recalculateprice-action.md
@@ -52,8 +52,42 @@ OData-Version: 4.0
 ### Client-side sample
 
 ```JavaScript
-var recalculatePriceRequest = new ODataContract.ReCalculatePriceRequest({guid: ClientUtility.Guid.create(Xrm.Page.data.entity.getId())}, Xrm.Page.data.entity.getEntityName());
-                Xrm.WebApi.online.execute(recalculatePriceRequest).then(() => {
-                );
+function RecalculatePrice(formContext) {
+    var entityName = formContext.data.entity.getEntityName();
+    var parameters = {};
+    var target = {};
+    target[entityName + "id"] = formContext.data.entity.getId();
+    target["@odata.type"] = "Microsoft.Dynamics.CRM." + entityName;
+    parameters.Target = target;
+
+    var recalculatePriceRequest = {
+        Target: parameters.Target,
+
+        getMetadata: function () {
+            return {
+                boundParameter: null,
+                parameterTypes: {
+                    "Target": {
+                        "typeName": "mscrm.crmbaseentity",
+                        "structuralProperty": 5
+                    }
+                },
+                operationType: 0,
+                operationName: "CalculatePrice"
+            };
+        }
+    };
+
+    Xrm.WebApi.online.execute(recalculatePriceRequest).then(
+        function success(result) {
+            if (result.ok) {
+                //Success
+            }
+        },
+        function (error) {
+            Xrm.Utility.alertDialog(error.message);
+        }
+    );
+}
 ```
 


### PR DESCRIPTION
The existing example cannot be run as is. It had references to unknown functions and objects as well as used an arrow function which does not work in IE 11.