### PR TITLE
Update provision-portal.md

### DIFF
--- a/ce/portals/provision-portal.md
+++ b/ce/portals/provision-portal.md
@@ -30,7 +30,9 @@ Portals are websites that you can customize to provide a more personalized exper
 -   Internal employees can create and see best practices.
 
 > [!NOTE]
-> To provision a portal, you must be assigned to the System Administrator role of the [!INCLUDE[pn-dynamics-crm](../includes/pn-dynamics-crm.md)] organization selected for the portal.
+> To provision a portal, you must be assigned to the System Administrator or System Customizer role of the [!INCLUDE[pn-dynamics-crm](../includes/pn-dynamics-crm.md)] organization selected for the portal.
+
+>In Azure AD you will also need the permissions required to create an application registration, [required permissions](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal).  The Global Administrator has this permission or they can assign the role to the user that will be provisioning the portal.  
 
 To complete provisioning a portal, after you have purchased a new portal license, return to your [!INCLUDE[pn-dynamics-crm](../includes/pn-dynamics-crm.md)] instance.
 


### PR DESCRIPTION
Updated the permissions required to provision a portal.  Contact dileeps@microsoft.com if confirmation is needed.  

Current:
 Note
To provision a portal, you must be assigned to the System Administrator role of the Dynamics 365 for Customer Engagement organization selected for the portal.

Updated:
 Note
To provision a portal, you must be assigned to the System Administrator or System Customizer role of the Dynamics 365 for Customer Engagement organization selected for the portal.

In Azure AD you will also need the permissions required to create an application registration, required permissions.  The Global Administrator has this permission or they can assign the role to the user that will be provisioning the portal.