### PR TITLE
Add Plugins/Workflow clarification

### DIFF
--- a/ce/developer/api-limits.md
+++ b/ce/developer/api-limits.md
@@ -22,9 +22,11 @@ search.app:
 - [!INCLUDE [cc_applies_to_update_9_0_0](../includes/cc_applies_to_update_9_0_0.md)]
 - [!INCLUDE [cc_applies_to_update_8_2_0](../includes/cc_applies_to_update_8_2_0.md)]
 
-We limit the number of API requests made by each user, per organization instance, within a five minute sliding window. Additionally, we limit the number of concurrent requests that may come in at one time.  When one of these limits is exceeded, an exception will be thrown by the platform.
+We limit the number of API requests made by each user, per organization instance, within a five minute sliding window. Additionally, we limit the number of concurrent requests that may come in at one time.  When one of these limits is exceeded, an exception will be thrown by the platform.  
 
 The limit will help ensure that users running applications cannot interfere with each other based on resource constraints. The limits will not affect normal users of the platform. Only applications that perform a large number of API requests may be affected. The limit will help provide a level of protection from random and unexpected surges in request volumes that threaten the availability and performance characteristics of the [!INCLUDE [pn-dyn-365](../includes/pn-dyn-365.md)] platform.
+
+Since plugins and custom workflow activities are executing on the server already, any API calls made using the IOrganziationService retrieved from the context, will not count against this external API requests limit. 
 
 If your application has the potential to exceed the limit, please consider the guidance given in the [What should I do if my application exceeds the limit?](#what-should-i-do-if-my-application-exceeds-the-limit) section below.
 

--- a/ce/developer/api-limits.md
+++ b/ce/developer/api-limits.md
@@ -26,7 +26,7 @@ We limit the number of API requests made by each user, per organization instance
 
 The limit will help ensure that users running applications cannot interfere with each other based on resource constraints. The limits will not affect normal users of the platform. Only applications that perform a large number of API requests may be affected. The limit will help provide a level of protection from random and unexpected surges in request volumes that threaten the availability and performance characteristics of the [!INCLUDE [pn-dyn-365](../includes/pn-dyn-365.md)] platform.
 
-Since plugins and custom workflow activities are executing on the server already, any API calls made using the IOrganziationService retrieved from the context, will not count against this external API requests limit. 
+Since plugins and custom workflow activities execute on the server independent of a logged on user, API calls made from plug-in code will not count against this external API request limit.
 
 If your application has the potential to exceed the limit, please consider the guidance given in the [What should I do if my application exceeds the limit?](#what-should-i-do-if-my-application-exceeds-the-limit) section below.
 


### PR DESCRIPTION
Many developers would be concerned if the calls within their plugins potentially contribute to this limit.  This would alleviate their concern and push them to do more work on the server, rather than a chatty API.