### PR TITLE
Clarify RSO Additional Instance eligibility

### DIFF
--- a/ce/field-service/rso-deployment.md
+++ b/ce/field-service/rso-deployment.md
@@ -44,8 +44,9 @@ To deploy Resource Scheduling Optimization, you must first do the following:
 
     The RSO instance is associated with a single Dynamics 365 for Customer Engagement organization in
     the tenant. You can change the associated organization through the RSO
-    deployment app’s page. If additional RSO instances are needed for dev/test,
-    contact your technical account manager.
+    deployment app’s page. If additional RSO instances are needed for dev/test and you have an
+    Enterprise Agreement with Microsoft, contact your technical account manager. Such instances are
+    not yet available to Cloud Solution Providers or retail purchase.
 
 ## Deployment steps 
 


### PR DESCRIPTION
RSO additional instances for dev/test require a licensing specialist to be involved. Clarifying the wording in the documentation to reflect that.