### PR TITLE
sql query update for delete all Data Export Profile tables and SPs

### DIFF
--- a/ce/admin/replicate-data-microsoft-azure-sql-database.md
+++ b/ce/admin/replicate-data-microsoft-azure-sql-database.md
@@ -430,7 +430,7 @@ DECLARE @sql nvarchar(max) = '';
 
 SELECT @sql += 'DROP TABLE ' + QUOTENAME([TABLE_SCHEMA]) + '.' + QUOTENAME([TABLE_NAME]) + ';'
 FROM [INFORMATION_SCHEMA].[TABLES]
-WHERE [TABLE_TYPE] = 'BASE TABLE' AND [TABLE_NAME] like @prefix + '_%' AND [TABLE_SCHEMA]= @schema;
+WHERE [TABLE_TYPE] = 'BASE TABLE' AND [TABLE_NAME] like @prefix + '\_%' ESCAPE '\' AND [TABLE_SCHEMA]= @schema;
 
 PRINT @sql
 EXEC SP_EXECUTESQL @sql;
@@ -440,7 +440,7 @@ PRINT 'Finished dropping all tables. Starting to drop all stored procedures now.
 SELECT @sql='';
 SELECT @sql += 'DROP PROCEDURE ' + QUOTENAME([ROUTINE_SCHEMA]) + '.' + QUOTENAME([ROUTINE_NAME]) + ';'
 FROM [INFORMATION_SCHEMA].[ROUTINES]
-WHERE [ROUTINE_TYPE] = 'PROCEDURE' AND [ROUTINE_NAME] like @prefix + '_%' AND [ROUTINE_SCHEMA]= @schema;
+WHERE [ROUTINE_TYPE] = 'PROCEDURE' AND [ROUTINE_NAME] like @prefix + '\_%' ESCAPE '\' AND [ROUTINE_SCHEMA]= @schema;
 PRINT @sql
 EXEC SP_EXECUTESQL @sql;
 
@@ -449,7 +449,7 @@ PRINT 'Finished dropping all stored procedures. Starting to drop all types now.'
 SELECT @sql=''; 
 SELECT @sql += 'DROP TYPE ' + QUOTENAME(SCHEMA_NAME([SCHEMA_ID])) + '.' +  QUOTENAME([NAME]) + ';'
 FROM SYS.TYPES
-WHERE is_user_defined = 1 AND [NAME] LIKE @prefix + '_%' AND [SCHEMA_ID]=SCHEMA_ID(@schema);
+WHERE is_user_defined = 1 AND [NAME] LIKE @prefix + '\_%' ESCAPE '\' AND [SCHEMA_ID]=SCHEMA_ID(@schema);
 
 PRINT @sql
 EXEC SP_EXECUTESQL @sql;


### PR DESCRIPTION
Delete all tables and stored procedures with specific prefix by using **prefix + '_%'** does not work as expected because of underscore ( _ ) char is wildcard in SQL.
We should use **prefix + '\\_%' ESCAPE '\\'**  instead of **prefix + '_%'**  .
