### PR TITLE
Update cc-ad-required-for-access-and-authentication.md

### DIFF
--- a/ce/customerengagement/on-premises/includes/cc-ad-required-for-access-and-authentication.md
+++ b/ce/customerengagement/on-premises/includes/cc-ad-required-for-access-and-authentication.md
@@ -1,1 +1,1 @@
-Active Directory service required for Active Directory access and authentication. This is used by Server Message Block (SMB) during organization creation  to create a 'template database' from the installation location on the CRM server to a UNC path on the SQL server. 
+Active Directory service required for Active Directory access and authentication. This is used by Server Message Block (SMB) during organization creation  to create a 'template database' from the installation location on the Dynamics 365 Server to a UNC path on the SQL server. 

--- a/ce/customerengagement/on-premises/includes/cc-ad-required-for-access-and-authentication.md
+++ b/ce/customerengagement/on-premises/includes/cc-ad-required-for-access-and-authentication.md
@@ -1,1 +1,1 @@
-Active Directory service required for Active Directory access and authentication.
+Active Directory service required for Active Directory access and authentication. This is used by Server Message Block (SMB) during organization creation  to create a 'template database' from the installation location on the CRM server to a UNC path on the SQL server. 


### PR DESCRIPTION
The existing description does not properly explain the need for opening this port. Without the additional details it is confusing why this would be necessary as Dynamics does not use this access/authorization method elsewhere.  Adding the comment clarifies the purpose for customers with more stringent processes for opening ports. 
See https://icm.ad.msft.net/imp/v3/incidents/details/168634117/home