### PR TITLE
Links to documentation were mixed up

### DIFF
--- a/ce/customerengagement/on-premises/admin/set-up-server-side-synchronization-of-email-appointments-contacts-and-tasks.md
+++ b/ce/customerengagement/on-premises/admin/set-up-server-side-synchronization-of-email-appointments-contacts-and-tasks.md
@@ -36,9 +36,9 @@ You can use [!INCLUDE[cc_server_side_synch](../includes/cc-server-side-synch.md)
   
  Choose one of the following scenarios to configure [!INCLUDE[cc_server_side_synch](../includes/cc-server-side-synch.md)] for your organization:  
   
--   [Connect Customer Engagement (on-premises) to Exchange Online](https://docs.microsoft.com/previous-versions/dynamicscrm-2016/administering-dynamics-365/mt622062%28v%3dcrm.8%29)  
+-   [Connect Customer Engagement (on-premises) to Exchange Online](https://docs.microsoft.com/previous-versions/dynamicscrm-2016/administering-dynamics-365/mt703269%28v%3dcrm.8%29) 
   
--   [Connect Customer Engagement (on-premises) to Exchange Server on-premises](https://docs.microsoft.com/previous-versions/dynamicscrm-2016/administering-dynamics-365/mt703269%28v%3dcrm.8%29)  
+-   [Connect Customer Engagement (on-premises) to Exchange Server on-premises](https://docs.microsoft.com/previous-versions/dynamicscrm-2016/administering-dynamics-365/mt622062%28v%3dcrm.8%29) 
   
 -   [Connect to a POP3 or SMTP server](../admin/connect-to-pop3-or-smtp-servers.md)
 


### PR DESCRIPTION
The links for "Connect Customer Engagement (on-premises) to Exchange Online" was switched with "Connect Customer Engagement (on-premises) to Exchange Server on-premises".