### PR TITLE
Update the Scheduling params docs

### DIFF
--- a/ce/field-service/perform-initial-configurations-setup.md
+++ b/ce/field-service/perform-initial-configurations-setup.md
@@ -78,8 +78,6 @@ Navigate to **Resource Scheduling > Administration > Scheduling Parameters**.
 
 Set **Connect to Maps** to **Yes**.
 
-The API key will populate automatically and use the Bing Maps API.
-
 > [!div class="mx-imgBorder"]
 > ![Screenshot of setting COnnect to Maps to yes](media/Perform-Initial-Configurations-image7.png)  
 


### PR DESCRIPTION
As the Bing Maps API key is now hidden, lets remove the line "The API key will populate automatically and use the Bing Maps API." to not give a conflicting message. there is already a note, which says the key is hidden starting 8.8.10.44+