### PR TITLE
Update download-tools-nuget.md

### DIFF
--- a/ce/customerengagement/on-premises/developer/download-tools-nuget.md
+++ b/ce/customerengagement/on-premises/developer/download-tools-nuget.md
@@ -39,6 +39,7 @@ You can download tools used in development from NuGet using the  powershell scri
 1. Copy and paste the following PowerShell script into the PowerShell window and press Enter.
 
     ```powershell
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     $sourceNugetExe = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
     $targetNugetExe = ".\nuget.exe"
     Remove-Item .\Tools -Force -Recurse -ErrorAction Ignore


### PR DESCRIPTION
Add a single line fix to the Powershell script to tell Powershell to to use TLS1.2 now TLS1.0 is deprecated see https://mikefactorial.com/2020/08/04/quick-fix-for-downloading-power-apps-sdk-tools/ for details.