### PR TITLE
BPA can only be imported for Dynamics 365 v9+

### DIFF
--- a/ce/unified-service-desk/admin/download-install-best-practices-analyzer.md
+++ b/ce/unified-service-desk/admin/download-install-best-practices-analyzer.md
@@ -54,6 +54,8 @@ Before you can install and deploy [!INCLUDE[pn-best-practices-analyzer](../../in
 
 ### Best Practices Analyzer for Unified Service Desk 4.1
 
+Only applies to Dynamics 365 version 9 or higher.
+
 [!INCLUDE[pn-best-practices-analyzer](../../includes/pn-best-practices-analyzer.md)] for [!INCLUDE[pn-unified-service-desk-4-1](../../includes/pn-unified-service-desk-4-1.md)] is available in [!INCLUDE[pn_unified_service_desk](../../includes/pn-unified-service-desk.md)] Web Client sample package.
 
 You can deploy a [!INCLUDE[pn_unified_service_desk](../../includes/pn-unified-service-desk.md)] [!INCLUDE[pn-best-practices-analyzer](../../includes/pn-best-practices-analyzer.md)] sample package using Package Deployer. [!INCLUDE[proc_more_information](../../includes/proc-more-information.md)] [Deploy sample Unified Service Desk applications using Package Deployer](../admin/deploy-sample-unified-service-desk-applications-using-package-deployer.md)
@@ -63,6 +65,8 @@ You can deploy a [!INCLUDE[pn_unified_service_desk](../../includes/pn-unified-se
 ::: moniker range="=dynamics-usd-4"  
 
 ### Best Practices Analyzer for Unified Service Desk 4.0
+
+Only applies to Dynamics 365 version 9 or higher.
 
 [!INCLUDE[pn-best-practices-analyzer](../../includes/pn-best-practices-analyzer.md)] for [!INCLUDE[pn-unified-service-desk-4-0](../../includes/pn-unified-service-desk-4-0.md)] is available in [!INCLUDE[pn_unified_service_desk](../../includes/pn-unified-service-desk.md)] Web Client sample package.
 


### PR DESCRIPTION
The Best Practice Analyzer downloads contains a solution file that applies only to Dynamics v9 or a higher version. Therefore, even if USD v4 is supported for Dynamics 8.2. It is not easily possible to apply the Best Practice Analyzer for this version via download. It is possible to change the version of the solution.xml file and then import again. This will work as a workaround.

The SolutionPackageVersion  value in the solution.xml file has to be changed from 9.0 to 8.2 or something else.