### PR TITLE
Fix incorrect cif docs

### DIFF
--- a/ce/customer-service/channel-integration-framework/reference/client-side-events.md
+++ b/ce/customer-service/channel-integration-framework/reference/client-side-events.md
@@ -26,8 +26,6 @@ Each event handler specifies a function within a JavaScript library and the para
 | [onPageNavigate](events/onPageNavigate.md) | Invoked when the main Unified Interface page navigation occurs. |
 | [onSendKBArticle](events/onSendKBArticle.md) | Invoked when the user selects the **Send** button in the Knowledge Base control. |
 | [onSizeChanged](events/onSizeChanged.md) | Invoked when the side panel width is changed. |
-| [onSessionSwitched](/dynamics365/customer-service/channel-integration-framework/referen/v2/reference/events/onSessionSwitched) | Invoked when the session is switched. |
-| [onSessionClosed](/dynamics365/customer-service/channel-integration-framework/referen/v2/reference/events/onSessionClosed) | Invoked when the session is closed. |
 | [CIFInitDone](events/cifinitdone.md) | Invoked when the Channel Integration framework is loaded to determine if Channel Integration Framework APIs are ready to be consumed. |
 
 

--- a/ce/customer-service/channel-integration-framework/toc.yml
+++ b/ce/customer-service/channel-integration-framework/toc.yml
@@ -2,7 +2,7 @@
   href: channel-integration-framework.md
   items:
   - name: "Choose between version 1.0 and version 2.0"
-    href: choose-between-versions.md    
+    href: choose-between-versions.md
   - name: "Channel Integration Framework version 1.0"
     href: overview-channel-integration-framework.md
   - name: "Channel Integration Framework version 2.0"
@@ -19,7 +19,7 @@
       items:
       - name: "Get Channel Integration Framework"
         href: get-channel-integration-framework.md
-      - name: "Sample softphone integration" 
+      - name: "Sample softphone integration"
         href: sample-softphone-integration.md
     - name: How-to
       items:
@@ -28,7 +28,7 @@
       - name: "Enable outbound communication (ClickToAct)"
         href: enable-outbound-communication-clicktoact.md
       - name: "Add Channel Integration Framework solution as a dependent solution"
-        href: add-cif-solution-dependent-solution.md   
+        href: add-cif-solution-dependent-solution.md
       - name: "Authenticate channel users to the channel (widget)"
         href: authenticate-channel-users.md
       - name: "Pass Dynamics 365 URL to widget library"
@@ -118,7 +118,7 @@
   - name: Version 2.0
     items:
     - name: "System requirements"
-      href:  v2/system-requirements-channel-integration-framework-v2.md    
+      href:  v2/system-requirements-channel-integration-framework-v2.md
     - name: "Architecture of version 2.0"
       href: v2/architecture-overview-channel-integration-framework-v2.md
     - name: Download
@@ -134,7 +134,7 @@
       - name: "Enable outbound communication (ClickToAct)"
         href: v2/enable-outbound-communication-clicktoact.md
       - name: "Add Channel Integration Framework solution as a dependent solution"
-        href: v2/add-cif-solution-dependent-solution.md   
+        href: v2/add-cif-solution-dependent-solution.md
       - name: "Authenticate channel users to the channel (widget)"
         href: v2/authenticate-channel-users.md
       - name: "Pass Dynamics 365 URL to widget library"
@@ -152,13 +152,13 @@
         - name: "Manage session templates"
           href: v2/session-templates-cif.md
         - name: "Manage application tab templates"
-          href: v2/application-tab-templates-cif.md      
+          href: v2/application-tab-templates-cif.md
         - name: "Manage notification templates"
           href: v2/notification-templates-cif.md
         - name: "Use automation dictionary to pass data parameter keys"
           href: v2/automation-dictionary-keys-cif.md
         - name: "Associate templates with scenarios"
-          href: v2/associate-templates-cif.md          
+          href: v2/associate-templates-cif.md
     - name: "Channel Analytics"
       href: v2/channel-analytics.md
     - name: JavaScript API Reference
@@ -232,7 +232,7 @@
           - name: "createTab"
             href: v2/reference/microsoft-ciframework/createtab.md
           - name: "getTabs"
-            href: v2/reference/microsoft-ciframework/gettabs.md  
+            href: v2/reference/microsoft-ciframework/gettabs.md
           - name: "focusTab"
             href: v2/reference/microsoft-ciframework/focustab.md
           - name: "getFocusedTab"
@@ -254,7 +254,7 @@
           - name: "logAnalyticsEvent"
             href: v2/reference/microsoft-ciframework/logAnalyticsEvent.md
       - name: "Client-side events"
-        href: reference/client-side-events.md
+        href: v2/reference/client-side-events.md
         items:
         - name: "onClickToAct"
           href: v2/reference/events/onclicktoact.md

--- a/ce/customer-service/channel-integration-framework/v2/reference/microsoft-ciframework/addHandler.md
+++ b/ce/customer-service/channel-integration-framework/v2/reference/microsoft-ciframework/addHandler.md
@@ -17,7 +17,28 @@ ms.custom:
 
 [!INCLUDE[addHandler-description](includes/addHandler-description.md)] 
 
-[!INCLUDE[token-addHandler](../../../shared/token-addHandler.md)]
+## Syntax
+
+`Microsoft.CIFramework.addHandler(eventName, handlerFunction);`
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| eventName | string | Yes | Name of the event for which the handler is set. <br>The supported events are as follows:<br><ul><li><b>onclicktoact:</b> The event is invoked when the outbound communication (ClickToAct) enabled field is clicked.</li> <li><b>onmodechanged:</b> The event is invoked when the panel mode is manually toggled between Minimized (0) and Docked (1). </li><li><b>onsizechanged:</b> The event is invoked when the panel size is manually changed by dragging. </li><li><b>onpagenavigate:</b> The event is triggered before a navigation event occurs on the main page </li><li><b>onsendkbarticle: </b> The event is invoked when the user clicks the send button on the KB control.</li><li><b>onsizechanged: </b> The event is invoked when the side panel width is changed.</li><li><b>onsessionswitched: </b> The event is invoked when the current session is switched.</li><li><b>onsessionclosed: </b> The event is invoked when the session is closed</li><li><b>cifinitdone: </b> The event is invoked when the Channel Integration Framework is loaded to determine if the CIF APIs are ready to be consumed.</li></ul>  |
+| handlerFunction | Function | Yes | The handler function is invoked when the any of the supported events trigger. |
+
+## Example
+
+
+```JavaScript
+handlerFunction = function(eventData) {
+console.log(eventData)
+return Promise.resolve();
+}
+
+Microsoft.CIFramework.addHandler("onmodechanged", handlerFunction);
+```
 
 ## Related topics
 

--- a/ce/customer-service/channel-integration-framework/v2/reference/microsoft-ciframework/addHandler.md
+++ b/ce/customer-service/channel-integration-framework/v2/reference/microsoft-ciframework/addHandler.md
@@ -17,28 +17,7 @@ ms.custom:
 
 [!INCLUDE[addHandler-description](includes/addHandler-description.md)] 
 
-## Syntax
-
-`Microsoft.CIFramework.addHandler(eventName, handlerFunction);`
-
-## Parameters
-
-| Name | Type | Required | Description |
-|------|------|----------|-------------|
-| eventName | string | Yes | Name of the event for which the handler is set. <br>The supported events are as follows:<br><ul><li><b>onclicktoact:</b> The event is invoked when the outbound communication (ClickToAct) enabled field is clicked.</li> <li><b>onmodechanged:</b> The event is invoked when the panel mode is manually toggled between Minimized (0) and Docked (1). </li><li><b>onsizechanged:</b> The event is invoked when the panel size is manually changed by dragging. </li><li><b>onpagenavigate:</b> The event is triggered before a navigation event occurs on the main page </li><li><b>onsendkbarticle: </b> The event is invoked when the user clicks the send button on the KB control.</li><li><b>onsizechanged: </b> The event is invoked when the side panel width is changed.</li><li><b>onsessionswitched: </b> The event is invoked when the current session is switched.</li><li><b>onsessionclosed: </b> The event is invoked when the session is closed</li><li><b>cifinitdone: </b> The event is invoked when the Channel Integration Framework is loaded to determine if the CIF APIs are ready to be consumed.</li></ul>  |
-| handlerFunction | Function | Yes | The handler function is invoked when the any of the supported events trigger. |
-
-## Example
-
-
-```JavaScript
-handlerFunction = function(eventData) {
-console.log(eventData)
-return Promise.resolve();
-}
-
-Microsoft.CIFramework.addHandler("onmodechanged", handlerFunction);
-```
+[!INCLUDE[token-addHandler](../../../shared/token-addHandler.md)]
 
 ## Related topics
 


### PR DESCRIPTION
The menu item had a link to the CIF1 docs under the CIF2 header, subsequently, the page that was linked was incorrectly updated in a previous commit.

CIF1 does not support multiple sessions, as such there are no event listeners for session changes.