### PR TITLE
Update download-tools-nuget.md

### DIFF
--- a/ce/customerengagement/on-premises/developer/download-tools-nuget.md
+++ b/ce/customerengagement/on-premises/developer/download-tools-nuget.md
@@ -45,7 +45,9 @@ You can download all SDK tools using the Windows PowerShell script provided belo
     Remove-Item .\Tools -Force -Recurse -ErrorAction Ignore
     Invoke-WebRequest $sourceNugetExe -OutFile $targetNugetExe
     Set-Alias nuget $targetNugetExe -Scope Global -Verbose
-        
+
+    .\nuget sources Add -Name Source -Source  https://api.nuget.org/v3/index.json
+
     ##
     ##Download Plugin Registration Tool
     ##

--- a/ce/customerengagement/on-premises/developer/download-tools-nuget.md
+++ b/ce/customerengagement/on-premises/developer/download-tools-nuget.md
@@ -46,7 +46,9 @@ You can download all SDK tools using the Windows PowerShell script provided belo
     Invoke-WebRequest $sourceNugetExe -OutFile $targetNugetExe
     Set-Alias nuget $targetNugetExe -Scope Global -Verbose
 
-    .\nuget sources Add -Name Source -Source  https://api.nuget.org/v3/index.json
+    if (-not (./nuget source | ? { $_ -like "*https://api.nuget.org/v3/index.json*"})) {
+      .\nuget sources Add -Name nuget.org.v3 -Source  https://api.nuget.org/v3/index.json
+    }
 
     ##
     ##Download Plugin Registration Tool


### PR DESCRIPTION
The current documentation contains a script located here https://docs.microsoft.com/en-us/dynamics365/customerengagement/on-premises/developer/download-tools-nuget?view=op-9-1 that fails with the following error:

`./nuget : Unable to find package 'Microsoft.CrmSdk.XrmTooling.PluginRegistrationTool'`

To resolve this issue, `https://api.nuget.org/v3/index.json` needs to be added as a source to nuget. This PR updates the documentation to include this step.

### Related Issues
https://github.com/MicrosoftDocs/dynamics-365-customer-engagement/issues/2467
https://github.com/MicrosoftDocs/dynamics-365-customer-engagement/issues/2437
https://github.com/MicrosoftDocs/dynamics-365-customer-engagement/issues/2419