### PR TITLE
Update perform-initial-configurations-setup.md

### DIFF
--- a/ce/field-service/perform-initial-configurations-setup.md
+++ b/ce/field-service/perform-initial-configurations-setup.md
@@ -100,7 +100,7 @@ Finally, let’s test geocoding.
 
 Geocoding is associating a latitude and longitude to an address. This allows dispatchers to locate work orders more effectively than an address.
 
-If addresses are geocoded, the system will automatically attempt to locate and populate the lattitude and longitude after entering an address on entities such as accounts, contacts, users, and work orders. Disallowing auto geocoding for addresses requires the user to select a manually select a geocode option in order to geocode an address.
+If addresses are geocoded, the system will automatically attempt to locate and populate the lattitude and longitude after entering an address on entities such as accounts, contacts, users, and work orders. Disallowing auto geocoding for addresses requires the user to manually select a geocode option in order to geocode an address.
 
 Go to **Field Service** > **Work Orders** and select **+New**.
 


### PR DESCRIPTION
Fixed a user reported typo on line 103. Now reads:  Disallowing auto geocoding for addresses requires the user to manually select a geocode option in order to geocode an address.