### PR TITLE
Rendered as source code instead of text

### DIFF
--- a/ce/outlook-addin/admin-guide/install.md
+++ b/ce/outlook-addin/admin-guide/install.md
@@ -56,7 +56,7 @@ To set up [!INCLUDE[pn_crm_for_outlook_full](../../includes/pn-crm-for-outlook-f
      >  If you have updated your Dynamics 365 apps  organzation to version 9.0 and the Dynamics 365 for Outlook client does not connect then you may need to install TLS 1.2. For more information, [Install TLS](https://support.microsoft.com/help/4054414/dynamics-365-for-outlook-update-for-version-9-0).
 
 
-~~~
+
 -   To install from a DVD, double-click **SetupClient.exe** in the installation folder for the architecture (32-bit or 64-bit) of [!INCLUDE[pn_MS_Office](../../includes/pn-ms-office.md)] that you’ve installed:
 
     -   ... \Client\amd64 for 64-bit
@@ -72,7 +72,7 @@ To set up [!INCLUDE[pn_crm_for_outlook_full](../../includes/pn-crm-for-outlook-f
     3.  If you see any dialog boxes titled **Security Warning**, click **Run** in each.
 
      The **Microsoft Dynamics 365 apps for Microsoft Office Outlook Setup** wizard starts.  
-~~~
+
 
 5. On the **License Agreement** page, review the information. If you accept the license agreement, select **I accept the license agreement**, and then click **Next**.
 


### PR DESCRIPTION
That section is rendered in the documentation in the same is written showing the markdown content instead of processing it.