### PR TITLE
Typo "resouce"→"resource"

### DIFF
--- a/ce/customerengagement/on-premises/snippets/csharp/CRMV8/scheduleandappointment/cs/scheduleresource.cs
+++ b/ce/customerengagement/on-premises/snippets/csharp/CRMV8/scheduleandappointment/cs/scheduleresource.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Crm.Sdk.Samples
                         Duration = 60,
                         NumberOfResults = 10,
                         ServiceId = _plumberServiceId,
-                        // The search window describes the time when the resouce can be scheduled.
+                        // The search window describes the time when the resource can be scheduled.
                         // It must be set.
                         SearchWindowStart = DateTime.Now.ToUniversalTime(),
                         SearchWindowEnd = DateTime.Now.AddDays(7).ToUniversalTime(),


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dynamics365/customerengagement/on-premises/developer/sample-search-openings-schedule-resource?view=op-9-1 
https://github.com/MicrosoftDocs/dynamics-365-customer-engagement/blob/main/ce/customerengagement/on-premises/snippets/csharp/CRMV8/scheduleandappointment/cs/scheduleresource.cs 
#PingMSFTDocs