### PR TITLE
Broken Link to sample

### DIFF
--- a/ce/customerengagement/on-premises/developer/sample-export-import-data-map.md
+++ b/ce/customerengagement/on-premises/developer/sample-export-import-data-map.md
@@ -25,7 +25,7 @@ search.audienceType:
 
 # Sample: Export and import a data map
 
-This sample shows how to create an import map (data map) in Dataverse, export it as an XML formatted data, import modified mappings, and create a new import map Dataverse based on the imported mappings. You can download the sample from [here](https://github.com/Microsoft/PowerApps-Samples/tree/master/cds/orgsvc/C%23/ExportImportDataMap).
+This sample shows how to create an import map (data map) in Dataverse, export it as an XML formatted data, import modified mappings, and create a new import map Dataverse based on the imported mappings. You can download the sample from [here](https://github.com/microsoft/PowerApps-Samples/tree/master/dataverse/orgsvc/C%23/ExportImportDataMap).
 
 [!include[cc-sample-note](includes/cc-sample-note.md)]
 


### PR DESCRIPTION
At the top of this page is this text "You can download the sample from here" which is pointing to the wrong URL.

Bad link: https://github.com/Microsoft/PowerApps-Samples/tree/master/cds/orgsvc/C%23/ExportImportDataMap
Good link: https://github.com/microsoft/PowerApps-Samples/tree/master/dataverse/orgsvc/C%23/ExportImportDataMap

It looks like the folder "cds" was renamed to "dataverse" but the page link wasn't updated. Might be an issue on other pages as well, but I didn't check it.