### PR TITLE
Update work-order-status-booking-status.md

### DIFF
--- a/ce/field-service/work-order-status-booking-status.md
+++ b/ce/field-service/work-order-status-booking-status.md
@@ -110,7 +110,7 @@ Every booking status change creates a booking timestamp to keep track of the upd
 
 #### Traveling
 
-- Updates **Start time** of bookable resource booking to current time.
+- When updates from Field Service Mobile, changing to Traveling updates **Start time** of bookable resource booking to current time.
 
 #### In Progress
 

--- a/ce/field-service/work-order-status-booking-status.md
+++ b/ce/field-service/work-order-status-booking-status.md
@@ -110,7 +110,7 @@ Every booking status change creates a booking timestamp to keep track of the upd
 
 #### Traveling
 
-- When updates from Field Service Mobile, changing to Traveling updates **Start time** of bookable resource booking to current time.
+- When a user changes the status in Field Service Mobile to *Traveling*, the system updates the **Start time** of the bookable resource booking to the current time.
 
 #### In Progress
 


### PR DESCRIPTION
Due to a customer request, making the "Traveling" status update more specific to highlight that the Start Time change occurs specifically from FSM.