### PR TITLE
Add "Address 1" to display name.

### DIFF
--- a/ce/customerengagement/on-premises/developer/entities/competitor.md
+++ b/ce/customerengagement/on-premises/developer/entities/competitor.md
@@ -159,7 +159,7 @@ These attributes return true for either **IsValidForCreate** or **IsValidForUpda
 |Property|Value|
 |--------|-----|
 |Description|Type the city for the primary address.|
-|DisplayName|City|
+|DisplayName|Address 1: City|
 |FormatName|Text|
 |IsLocalizable|False|
 |IsValidForForm|True|
@@ -175,7 +175,7 @@ These attributes return true for either **IsValidForCreate** or **IsValidForUpda
 |Property|Value|
 |--------|-----|
 |Description|Type the country or region for the primary address.|
-|DisplayName|Country/Region|
+|DisplayName|Address 1: Country/Region|
 |FormatName|Text|
 |IsLocalizable|False|
 |IsValidForForm|True|

--- a/ce/customerengagement/on-premises/developer/entities/lead.md
+++ b/ce/customerengagement/on-premises/developer/entities/lead.md
@@ -224,7 +224,7 @@ These attributes return true for either **IsValidForCreate** or **IsValidForUpda
 |Property|Value|
 |--------|-----|
 |Description|Type the city for the primary address.|
-|DisplayName|City|
+|DisplayName|Address 1: City|
 |FormatName|Text|
 |IsLocalizable|False|
 |IsValidForForm|True|
@@ -240,7 +240,7 @@ These attributes return true for either **IsValidForCreate** or **IsValidForUpda
 |Property|Value|
 |--------|-----|
 |Description|Type the country or region for the primary address.|
-|DisplayName|Country/Region|
+|DisplayName|Address 1: Country/Region|
 |FormatName|Text|
 |IsLocalizable|False|
 |IsValidForForm|True|

--- a/ce/customerengagement/on-premises/developer/entities/publisher.md
+++ b/ce/customerengagement/on-premises/developer/entities/publisher.md
@@ -138,7 +138,7 @@ These attributes return true for either **IsValidForCreate** or **IsValidForUpda
 |Property|Value|
 |--------|-----|
 |Description|City name for address 1.|
-|DisplayName|City|
+|DisplayName|Address 1: City|
 |FormatName|Text|
 |IsLocalizable|False|
 |IsValidForForm|True|
@@ -154,7 +154,7 @@ These attributes return true for either **IsValidForCreate** or **IsValidForUpda
 |Property|Value|
 |--------|-----|
 |Description|Country/region name for address 1.|
-|DisplayName|Country/Region|
+|DisplayName|Address 1: Country/Region|
 |FormatName|Text|
 |IsLocalizable|False|
 |IsValidForForm|True|

--- a/ce/sales/developer/entities/competitor.md
+++ b/ce/sales/developer/entities/competitor.md
@@ -163,7 +163,7 @@ These columns/attributes return true for either **IsValidForCreate** or **IsVali
 |Property|Value|
 |--------|-----|
 |Description|Type the city for the primary address.|
-|DisplayName|City|
+|DisplayName|Address 1: City|
 |FormatName|Text|
 |IsLocalizable|False|
 |IsValidForForm|True|
@@ -179,7 +179,7 @@ These columns/attributes return true for either **IsValidForCreate** or **IsVali
 |Property|Value|
 |--------|-----|
 |Description|Type the country or region for the primary address.|
-|DisplayName|Country/Region|
+|DisplayName|Address 1: Country/Region|
 |FormatName|Text|
 |IsLocalizable|False|
 |IsValidForForm|True|

--- a/ce/sales/developer/entities/lead.md
+++ b/ce/sales/developer/entities/lead.md
@@ -238,7 +238,7 @@ These columns/attributes return true for either **IsValidForCreate** or **IsVali
 |Property|Value|
 |--------|-----|
 |Description|Type the city for the primary address.|
-|DisplayName|City|
+|DisplayName|Address 1: City|
 |FormatName|Text|
 |IsLocalizable|False|
 |IsValidForForm|True|
@@ -254,7 +254,7 @@ These columns/attributes return true for either **IsValidForCreate** or **IsVali
 |Property|Value|
 |--------|-----|
 |Description|Type the country or region for the primary address.|
-|DisplayName|Country/Region|
+|DisplayName|Address 1: Country/Region|
 |FormatName|Text|
 |IsLocalizable|False|
 |IsValidForForm|True|


### PR DESCRIPTION
Prefix `Address 1: ` added to `address1_city` and `address1_country` where it was missing and similar ones with `Address 2: ` exist. Make it consistent with other attributes for Address 1 display names.