### PR TITLE
Add Refresh step to Post configuration for custom entity

### DIFF
--- a/ce/customerengagement/on-premises/customize/notes-control-legacy.md
+++ b/ce/customerengagement/on-premises/customize/notes-control-legacy.md
@@ -29,6 +29,7 @@ search.audienceType:
 1. [!INCLUDE[proc_settings_postconfig](../includes/proc-settings-postconfig.md)]  
   
 2. Locate the record for your custom entity.  
+   If the custom entity is not listed, select **Refresh** in the command bar.
   
 3. Make sure that **Enable walls for this type of record form** is selected and save the record.  
   


### PR DESCRIPTION
Step by step guide was missing a crucial step: Post Configurations are not created by creating entities/activating activities/publishing (for online at least) but by pressing the refresh button. Without this step the custom entity won't be found.

Googling "dynamics 365 enable posts for custom entity" finds this article first and no similar article that would apply for online. 
Mentions of the need to refresh: 
https://community.dynamics.com/forums/thread/details/?threadid=00449fbe-945c-4022-b8dc-cd01da9a6982 
https://community.dynamics.com/forums/thread/details/?threadid=dc24e009-17f5-4b4a-9634-b452487732aa
https://passion4dynamics.com/tag/how-to-enable-post-for-custom-entity/ 
https://neilparkhurst.com/2016/07/08/enable-a-custom-entity-for-yammer-or-posts/

![image](https://github.com/MicrosoftDocs/dynamics-365-customer-engagement/assets/9168648/0f485ca2-4e0f-4955-a30e-83e876d095d3)
