### PR TITLE
Enable enhanced experience for email attachments - Configuration wording

### DIFF
--- a/ce/customer-service/administer/add-enhanced-attachment-control.md
+++ b/ce/customer-service/administer/add-enhanced-attachment-control.md
@@ -31,8 +31,8 @@ You can enable the drag and drop feature for files to be added as attachments fo
 1. In [Power Apps](https://make.powerapps.com/), select the environment that contains your solution.
 1. Select **Tables**> **Email**> **Forms** and then select the required form.
 1. Edit **Email body** > **Components** > **Rich Text Editor Control**.
-1. Edit **Custom Configuration URL** and add the following configuration:
-     
+1. Edit the configuration linked in **Custom Configuration URL** to contain the following configuration:
+ 
      ```
         "base64FileUploader":true,
         "attachmentEntity": {
@@ -44,8 +44,8 @@ You can enable the drag and drop feature for files to be added as attachments fo
         "relatedEntityName": "emails",
         "relatedFieldName": "objectid_email"
         }    
-
      ```
+More information: [Customize the rich text editor control](/powerapps-docs/maker/model-driven-apps/rich-text-editor-control#customize-the-rich-text-editor-control)
 1. Save and publish the form.
 
 ## Next steps


### PR DESCRIPTION
Changed wording for how to enter the configuration and linked guide to configure it.
Trying to enter the given json into the configuration property will not work because of the 100 character limit.