### PR TITLE
Fix typo: singe -> single

### DIFF
--- a/ce/field-service/work-with-schedule-board.md
+++ b/ce/field-service/work-with-schedule-board.md
@@ -1,7 +1,7 @@
 ---
 title: Use the schedule board in Field Service
 description: Learn about the schedule board experience in Dynamics 365 Field Service.
-ms.date: 05/08/2024
+ms.date: 05/14/2024
 ms.topic: how-to
 author: clearab
 ms.author: anclear
@@ -28,7 +28,7 @@ Select **Suggest resources (Preview)** to get suggestions from Resource Scheduli
 
 Select **Book resources (Preview)** to let the system find the optimal resources and book directly.
 
-### Optimization the schedule of a single resource
+### Optimize the schedule of a single resource
 
 After a resource's planned schedule has changed due to cancellations or emergency work, you can use Resource Scheduling Optimization for reoptimization. To optimize only a resource's schedule, right-click a resource on the schedule board and select **Optimize schedule**. For more information, see [Single resource optimization with Resource Scheduling Optimization](rso-single-resource-optimization.md).
 

--- a/ce/field-service/work-with-schedule-board.md
+++ b/ce/field-service/work-with-schedule-board.md
@@ -28,7 +28,7 @@ Select **Suggest resources (Preview)** to get suggestions from Resource Scheduli
 
 Select **Book resources (Preview)** to let the system find the optimal resources and book directly.
 
-### Optimization the schedule of a singe resource
+### Optimization the schedule of a single resource
 
 After a resource's planned schedule has changed due to cancellations or emergency work, you can use Resource Scheduling Optimization for reoptimization. To optimize only a resource's schedule, right-click a resource on the schedule board and select **Optimize schedule**. For more information, see [Single resource optimization with Resource Scheduling Optimization](rso-single-resource-optimization.md).
 


### PR DESCRIPTION
Fix typo: singe -> single

Whole line could potentially be reworded, but this is a glaring typo in a header. I would additionally suggest adding a preposition after Optimization or changing it to Optimizing, but that's a more subjective change.