### PR TITLE
Remove sas uri from sales-apps.svg

### DIFF
--- a/ce/sales/media/sales-apps.svg
+++ b/ce/sales/media/sales-apps.svg
@@ -4243,7 +4243,7 @@
                                    height="40.00"
                                    aria-label="Customer Service admin center icon"
                                    clip-path="url(#imgClip-lxx7k2k6k7vybao0pvn)"
-                                   data-src="https://pafeblobprodby.blob.core.windows.net/20240318t000000z1e15a3fd2e11465d87dc6957a33004a8/backgroundimageicon.png?sv=2018-03-28&amp;sr=c&amp;sig=9xs768MmAVGGT8hOoVZ4YWRxxwwhleCt5njF7TIcHgI%3D&amp;se=2024-08-15T21%3A13%3A14Z&amp;sp=rl" /></g></g><g
+                                   data-src="" /></g></g><g
                                    data-tag="div"
                                    id="ohp-fui-CardHeader__header1181"
                                    data-z-index="auto"
@@ -4690,7 +4690,7 @@
                                    height="40.00"
                                    aria-label="SFTest icon"
                                    clip-path="url(#imgClip-lxx7k2lybhm5yxnpw7p)"
-                                   data-src="https://pafeblobprodby.blob.core.windows.net/20220424t000000z598211e83b7c41038aba323b4c9c2cc2/logoSmallFile?sv=2018-03-28&amp;sr=c&amp;sig=TcWUNAz2jAvQTzGRsuG1ZkHg1T4x048njmE9AW8nEW8%3D&amp;se=2024-08-15T03%3A45%3A50Z&amp;sp=rl" /></g></g><g
+                                   data-src="" /></g></g><g
                                    data-tag="div"
                                    id="ohp-fui-CardHeader__header1241"
                                    data-z-index="auto"
@@ -4913,7 +4913,7 @@
                                    height="40.00"
                                    aria-label="Customer Service Hub icon"
                                    clip-path="url(#imgClip-lxx7k2mmy39wb56ekjc)"
-                                   data-src="https://pafeblobprodcq.blob.core.windows.net/20230713t000000zbff8ec4412474ab7a2d4dc8334051266/backgroundimageicon.png?sv=2018-03-28&amp;sr=c&amp;sig=BIlL7CR1%2F%2BgT43ORTDH8RnTo7%2FcMgGdvcp9rAxsaE%2F8%3D&amp;se=2024-08-15T21%3A13%3A14Z&amp;sp=rl" /></g></g><g
+                                   data-src="" /></g></g><g
                                    data-tag="div"
                                    id="ohp-fui-CardHeader__header1261"
                                    data-z-index="auto"


### PR DESCRIPTION
We got a security notice to remove our generated blob sas uri from this image 
![image](https://github.com/MicrosoftDocs/dynamics-365-customer-engagement/assets/151775199/f51a28bd-4632-4c16-8c90-d624eebdb317)
