### PR TITLE
Document configurable service account requirements

### DIFF
--- a/ce/field-service/accounts.md
+++ b/ce/field-service/accounts.md
@@ -1,7 +1,7 @@
 ---
 title: Create and manage customer accounts in Field Service
 description: Learn how to create and manage service accounts and billing accounts in Dynamics 365 Field Service. Set up accounts before creating work orders.
-ms.date: 05/07/2026
+ms.date: 06/24/2026
 author: jshotts
 ms.author: jasonshotts
 ms.topic: how-to
@@ -10,7 +10,7 @@ ms.custom: bap-template
 
 # Create and manage customer accounts
 
-Accounts represent the customers your field service organization works with. Before you create work orders or schedule resources, set up accounts to track where service is delivered and who receives invoices.
+Accounts represent the customers your field service organization works with. For account-based service processes, set up accounts to track where service is delivered and who receives invoices before you create work orders or schedule resources. Some work order types can allow work orders without Service Account for scenarios such as B2C service, internal maintenance, project-centered work, or integrations where service context comes from another source.
 
 Two main types of accounts exist:
 
@@ -19,6 +19,8 @@ Two main types of accounts exist:
 - **Billing account** represents the account that receives invoices for the work provided. Usually, it's a shared account for multiple service accounts that belong to a central organization.
 
 For example, a wine producer corporation owns several vineyards. Each vineyard is a service account. The corporation is the billing account.
+
+Service accounts remain important when work orders use account-specific defaults such as service location, billing account, price list, tax settings, service territory, travel charges, work hour template, or work order instructions. If your organization creates work orders without Service Account, make sure the relevant Work Order Type and business process define how those details are captured. For more information, go to [Configure service account requirements for work orders](configure-service-account-requirements-work-orders.md).
 
 ## Create a service account
 

--- a/ce/field-service/configure-service-account-requirements-work-orders.md
+++ b/ce/field-service/configure-service-account-requirements-work-orders.md
@@ -1,0 +1,90 @@
+---
+title: Configure service account requirements for work orders
+description: Learn how to configure whether Service Account is required for work orders by Work Order Type in Dynamics 365 Field Service.
+ms.date: 06/24/2026
+ms.topic: how-to
+author: jasonccohen
+ms.author: jacoh
+ms.reviewer: puneetsingh
+ms.custom: bap-template
+---
+
+# Configure service account requirements for work orders
+
+Service Account identifies the account receiving service for a work order. Many Field Service processes use Service Account to provide service address, billing defaults, price list, tax settings, service territory, work instructions, customer assets, and other account-specific context.
+
+Some service processes use a different primary context. For example, B2C service might center on an individual contact, internal maintenance might center on an internal team or functional location, and integrations might represent customer context through a project, company, party, or external system reference.
+
+Use Work Order Type settings to configure whether Service Account is required.
+
+## When to require Service Account
+
+Require Service Account when the work order process depends on account-derived context.
+
+Examples:
+
+- B2B onsite service
+- Account-specific billing defaults
+- Service territory derived from an account
+- Work instructions stored on the account
+- Customer assets associated with an account location
+- Entitlements, agreements, or reporting that depend on account context
+
+## When to allow work orders without Service Account
+
+Allow work orders without Service Account when the work order type supports service scenarios where another record or process provides the primary context.
+
+Examples:
+
+- B2C service for individual customers
+- Internal maintenance
+- Project-centered work
+- Functional-location-centered work
+- Integrations where the servicing context can come from a party, company, project, or external system
+- Mixed work order types that can include a Service Account for some work orders and omit it for others
+
+## Configure a work order type
+
+1. In Field Service, change to the **Settings** area.
+1. Under **Work Orders**, select **Work Order Types**.
+1. Create or open a work order type.
+1. Set whether **Service Account** is required.
+1. Select **Save & Close**.
+
+## Create a work order without Service Account
+
+1. Create a work order.
+1. Select a Work Order Type where Service Account isn't required.
+1. Leave Service Account blank.
+1. Enter the remaining details required by your process, such as service location, contact, price list, billing context, service territory, functional location, project, or instructions.
+1. Save the work order.
+
+## Important considerations
+
+- If Service Account is selected, Field Service can use account-derived context such as service address, billing defaults, territory, tax settings, work instructions, and related customer information.
+- If Service Account isn't selected, provide the required service, billing, location, scheduling, and integration context through the work order fields and related records that apply to the scenario.
+- Review forms, business rules, flows, integrations, reports, and custom plug-ins that reference Service Account.
+- Require Service Account for work order types that rely on agreements, entitlements, customer assets, or billing rules that require account context.
+
+## Troubleshooting
+
+### I can't save a work order without Service Account
+
+Confirm that the selected Work Order Type allows work orders without Service Account. Also check custom business rules, Power Automate flows, plug-ins, or required form fields that might require Service Account.
+
+### Account-derived fields aren't populated
+
+If Service Account is blank, the work order can't inherit details from an account. Enter those details manually or configure your process to derive them from another source.
+
+### My integration needs customer or company context
+
+Update the integration to check the selected Work Order Type and handle work orders with or without Service Account. Make sure the integration receives any required customer, company, location, billing, tax, project, or party context from the appropriate field or related record.
+
+## Next steps
+
+- [Create a work order](create-work-order.md)
+- [Create a work order type](create-work-order-types.md)
+- [Create work orders using Power Automate](create-work-order-flow.md)
+- [Create work orders using the Dataverse Web API](create-work-order-api-example.md)
+
+[!INCLUDE[footer-include](../includes/footer-banner.md)]

--- a/ce/field-service/create-work-order-api-example.md
+++ b/ce/field-service/create-work-order-api-example.md
@@ -1,7 +1,7 @@
 ---
 title: "Create work orders using the Dataverse Web API"
 description: "Learn how to create one or multiple work orders in Dynamics 365 Field Service using the Dataverse Web API with HTTP/JSON examples."
-ms.date: 04/07/2026
+ms.date: 06/24/2026
 ms.topic: how-to
 author: vhorvathms
 ms.author: vhorvath
@@ -18,10 +18,10 @@ This article provides examples of creating work orders in Dynamics 365 Field Ser
 
 - A Dynamics 365 Field Service environment with the Web API endpoint (for example, `https://yourorg.api.crm.dynamics.com/api/data/v9.2/`).
 - An authenticated request using OAuth 2.0. Learn more in [Authenticate to Dataverse with the Web API](/power-apps/developer/data-platform/webapi/authenticate-web-api).
-- Existing records for the required lookup fields:
-  - **Service Account** (`account` entity)
+- Existing records for the lookup fields used by your work order process:
   - **Work Order Type** (`msdyn_workordertype` entity)
-  - **Price List** (`pricelevel` entity)
+  - **Price List** (`pricelevel` entity), if required by your process
+  - **Service Account** (`account` entity), if the selected Work Order Type requires Service Account or if you want account-derived context
 
 > [!IMPORTANT]
 > The GUIDs in the following examples are fictitious. Replace them with the actual record IDs from your Dynamics 365 environment.
@@ -29,6 +29,8 @@ This article provides examples of creating work orders in Dynamics 365 Field Ser
 ## Create a single work order
 
 Send a `POST` request to the `msdyn_workorders` entity set to create a work order. Learn more in [Create a table row using the Web API](/power-apps/developer/data-platform/webapi/create-entity-web-api).
+
+The examples in this article include Service Account. If the selected Work Order Type allows work orders without Service Account, omit `msdyn_serviceaccount@odata.bind` when the work order uses another service context. For more information, go to [Configure service account requirements for work orders](configure-service-account-requirements-work-orders.md).
 
 ### HTTP request
 
@@ -53,6 +55,29 @@ Authorization: Bearer <access_token>
 ### HTTP response
 
 A successful request returns `HTTP 204 No Content` with a `OData-EntityId` header containing the URL of the new work order record.
+
+### Create a work order without Service Account
+
+Use this pattern only when the selected Work Order Type allows work orders without Service Account.
+
+```http
+POST [Organization URL]/api/data/v9.2/msdyn_workorders
+Accept: application/json
+Content-Type: application/json
+OData-MaxVersion: 4.0
+OData-Version: 4.0
+Authorization: Bearer <access_token>
+
+{
+  "msdyn_workordertype@odata.bind": "/msdyn_workordertypes(a1b2c3d4-5678-9abc-def0-1234567890cd)",
+  "msdyn_pricelist@odata.bind": "/pricelevels(f1e2d3c4-5678-9abc-def0-1234567890ef)",
+  "msdyn_systemstatus": 690970000,
+  "msdyn_taxable": false,
+  "msdyn_instructions": "Internal maintenance request"
+}
+```
+
+When Service Account is omitted, include the location, billing, contact, and service context required by your process through the appropriate work order fields or related records.
 
 ## Create multiple work orders
 
@@ -141,11 +166,11 @@ Common error responses when creating work orders:
 
 | Status Code | Reason | Resolution |
 |---|---|---|
-| `400 Bad Request` | Missing required fields or invalid field values. | Verify that all required fields (`msdyn_serviceaccount`, `msdyn_workordertype`, `msdyn_pricelist`, `msdyn_systemstatus`, `msdyn_taxable`) are included with valid values. |
+| `400 Bad Request` | Missing required fields or invalid field values. | Verify that all fields required by your selected Work Order Type and business process are included with valid values. `msdyn_serviceaccount` is required when the selected Work Order Type requires Service Account. It can be omitted only when the selected Work Order Type allows work orders without Service Account. |
 | `400 Bad Request` (code `0x80060888`) | Lookup field value is a bare GUID without an entity set path. | Use the full OData entity reference format, for example `/accounts(guid)` instead of just the GUID. |
 | `401 Unauthorized` | Missing or expired access token. | Refresh or obtain a new OAuth 2.0 access token. |
 | `403 Forbidden` | Insufficient privileges. | Ensure the user has the **Field Service - Dispatcher** or **Field Service - Administrator** security role. |
-| `404 Not Found` | A referenced lookup record doesn't exist. | Verify that the GUIDs for Service Account, Work Order Type, and Price List reference existing records. |
+| `404 Not Found` | A referenced lookup record doesn't exist. | Verify that the GUIDs for referenced lookup records, such as Service Account, Work Order Type, and Price List, reference existing records. If you omit Service Account, confirm that the selected Work Order Type allows work orders without Service Account. |
 
 ## Related content
 

--- a/ce/field-service/create-work-order-flow.md
+++ b/ce/field-service/create-work-order-flow.md
@@ -1,7 +1,7 @@
 ---
 title: Create work orders using Power Automate
 description: Learn how to automatically create work orders in Dynamics 365 Field Service using Power Automate flows with the Dataverse connector.
-ms.date: 04/06/2026
+ms.date: 06/24/2026
 ms.topic: how-to
 author: vhorvathms
 ms.author: vhorvath
@@ -21,10 +21,10 @@ Power Automate flows use the **Microsoft Dataverse** connector to interact with 
 - At least one of the following Field Service security roles assigned to the flow's connection account. Learn more in [Set up users and security roles](users-licenses-permissions.md).
   - Field Service - Dispatcher
   - Field Service - Administrator
-- Existing records for the required lookup fields:
-  - **Service Account** (`account` entity)
+- Existing records for the lookup fields used by your work order process:
   - **Work Order Type** (`msdyn_workordertype` entity)
-  - **Price List** (`pricelevel` entity)
+  - **Price List** (`pricelevel` entity), if required by your process
+  - **Service Account** (`account` entity), if the selected Work Order Type requires Service Account or if you want account-derived context
 
 ## Option 1: Create a work order when a Dataverse record changes
 
@@ -64,14 +64,14 @@ Use this pattern to create a work order in response to a change in another Datav
    | Field | Value |
    |---|---|
    | **Work Order Number** | Enter the expression `guid()` as a placeholder. The Work Order Number field is required by the Dataverse connector UI, but Field Service's autonumber plugin automatically assigns the correct sequential work order number when the record is saved. To enter an expression, select the field, switch to the **Expression** tab in the dynamic content panel, type `guid()`, and select **OK**. |
-   | **Service Account** | Select the account using the search field, or enter the expression `concat('/accounts(', 'service-account-guid', ')')` in the **Expression** tab if you need to use a hardcoded or dynamic GUID. See below for how to find this. |
+   | **Service Account** | Required only when the selected Work Order Type requires Service Account. Select the account using the search field, or enter the expression `concat('/accounts(', 'service-account-guid', ')')` in the **Expression** tab if you need to use a hardcoded or dynamic GUID. Leave this field blank for work order types where Service Account isn't required and the work order uses another service context. |
    | **Work Order Type** | Select the work order type using the search field, or enter the expression `concat('/msdyn_workordertypes(', 'work-order-type-guid', ')')` in the **Expression** tab if you need to use a hardcoded or dynamic GUID. See below for how to find this. |
    | **Price List** | Select the price list using the search field, or enter the expression `concat('/pricelevels(', 'your-price-list-guid', ')')` in the **Expression** tab if you need to use a hardcoded or dynamic GUID. If you retrieve the price list dynamically using a **List rows** action inside a **For each** loop, use `concat('/pricelevels(', items('YourLoopName')?['pricelevelid'], ')')` instead, replacing `YourLoopName` with your loop's name. See below for how to find this. |
    | **System Status** | `690970000` (Unscheduled) |
    | **Taxable** | `false` |
    | **Instructions** | Use dynamic content from the trigger, for example the asset name |
 
-   **Service Account**: Type the account name directly in the **Service Account** field to search for and select it. If the trigger is a Customer Asset change and the asset is linked to an account, you can instead select **Account (Customer Assets)** from the dynamic content panel. If you need to use a GUID directly, go to **Service** area > **Customers** > **Accounts** in Field Service, open the account, and copy the record ID from the browser URL (the value between `%7B` and `%7D`, or the plain GUID if the URL is unencoded).
+   **Service Account**: Type the account name directly in the **Service Account** field to search for and select it. If the trigger is a Customer Asset change and the asset is linked to an account, you can instead select **Account (Customer Assets)** from the dynamic content panel. If you need to use a GUID directly, go to **Service** area > **Customers** > **Accounts** in Field Service, open the account, and copy the record ID from the browser URL (the value between `%7B` and `%7D`, or the plain GUID if the URL is unencoded). For more information about when Service Account is required, go to [Configure service account requirements for work orders](configure-service-account-requirements-work-orders.md).
 
    **Work Order Type**: Type the work order type name directly in the **Work Order Type** field to search for and select it. If you need to use a GUID directly, go to **Settings** area > **Work Order** > **Work Order Types** in Field Service, open the work order type, and copy the record ID from the browser URL.
 
@@ -105,9 +105,11 @@ Use this pattern to create a work order from an external system, such as a custo
        "priceListId": { "type": "string" },
        "instructions": { "type": "string" }
      },
-     "required": ["serviceAccountId", "workOrderTypeId", "priceListId"]
+     "required": ["workOrderTypeId", "priceListId"]
    }
    ```
+
+   Include `serviceAccountId` when the selected Work Order Type requires Service Account or when you want the work order to use account-derived context. Omit it for work order types where Service Account isn't required.
 
 1. For **Who can trigger the flow**, select one of the following options:
 
@@ -127,9 +129,9 @@ Use this pattern to create a work order from an external system, such as a custo
    Content-Type: application/json
 
    {
-     "serviceAccountId": "<account record GUID>",
      "workOrderTypeId": "<work order type record GUID>",
      "priceListId": "<price list record GUID>",
+     "serviceAccountId": "<optional account record GUID>",
      "instructions": "Reported issue: equipment not functioning"
    }
    ```
@@ -149,7 +151,7 @@ Use this pattern to create a work order from an external system, such as a custo
    | Work order field | Value |
    |---|---|
    | **Work Order Number** | Enter the expression `guid()` as a placeholder. The Work Order Number field is required by the Dataverse connector UI, but Field Service's autonumber plugin automatically assigns the correct sequential work order number when the record is saved. To enter an expression, select the field, switch to the **Expression** tab in the dynamic content panel, type `guid()`, and select **OK**. | 
-   | **Service Account** | `concat('/accounts(', triggerBody()?['serviceAccountId'], ')')` |
+   | **Service Account** | Use `concat('/accounts(', triggerBody()?['serviceAccountId'], ')')` only when `serviceAccountId` is provided. If Service Account isn't required for the selected Work Order Type and the request doesn't include `serviceAccountId`, don't map this lookup field. |
    | **Work Order Type** | `concat('/msdyn_workordertypes(', triggerBody()?['workOrderTypeId'], ')')` |
    | **Price List** | `concat('/pricelevels(', triggerBody()?['priceListId'], ')')` |
    | **System Status** | `690970000` (Unscheduled) |

--- a/ce/field-service/create-work-order-from-agreement.md
+++ b/ce/field-service/create-work-order-from-agreement.md
@@ -1,7 +1,7 @@
 ---
 title: Create work orders from an agreement
 description: Learn how agreements automatically generate work orders in Dynamics 365 Field Service, how to verify generation, and how to manually trigger work order creation from a booking date.
-ms.date: 03/24/2026
+ms.date: 06/24/2026
 ms.topic: how-to
 author: jasonccohen
 ms.author: jacoh
@@ -35,6 +35,8 @@ The generated work order inherits key values from the agreement and the ABS:
 | **Service Tasks** | **Work Order Service Tasks** |
 | **Pre/Post Booking Flexibility** | **Date Window Start / Date Window End** |
 | **Time Window Start / End** | **Time Window Start / End** |
+
+Agreements commonly use a Service Account because recurring service is often tied to an account, site, or customer location. If your organization configures a Work Order Type that allows work orders without Service Account, validate the agreement and booking setup behavior before using it for recurring work generation. Make sure generated work orders include the required location, billing, price list, territory, and service context for your process. For more information, go to [Configure service account requirements for work orders](configure-service-account-requirements-work-orders.md).
 
 ## Prerequisites
 
@@ -96,6 +98,10 @@ If you configured **Auto Generate Booking** on the ABS, the work order is automa
 **Booking dates exist but no work order link appears**
 
 The booking date status shows **Active** until the date falls within the generation window. Check whether today's date is within the **Generate Work Orders Day in Advance** window relative to the booking date.
+
+**Generated work orders are missing account-derived details**
+
+If generated work orders don't have a Service Account, confirm that the Work Order Type allows work orders without Service Account. Then verify how your agreement or booking setup provides details that are commonly derived from Service Account, such as service territory, price list, billing context, tax settings, or work instructions.
 
 **Generated work orders are missing products, services, or service tasks**
 

--- a/ce/field-service/create-work-order-from-case.md
+++ b/ce/field-service/create-work-order-from-case.md
@@ -1,7 +1,7 @@
 ---
 title: Create a work order from a case
 description: Learn how to create a work order from a case in Dynamics 365 Field Service using the Case to Work Order business process flow.
-ms.date: 02/27/2026
+ms.date: 06/24/2026
 ms.topic: how-to
 author: vhorvathms
 ms.author: vhorvath
@@ -38,7 +38,7 @@ A work order in Dynamics 365 Field Service can be created from a case using the 
 
 1. On the new work order form, verify or fill in the required fields:
 
-   - **Service Account**: Populated from the case's customer account.
+   - **Service Account**: Populated from the case's customer account when one is available and when the selected Work Order Type requires or uses Service Account. If the case is associated with a contact or another customer model and the selected Work Order Type allows work orders without Service Account, you can create the work order without selecting a Service Account.
    - **Work Order Type**: Select a work order type from the list or [create a new work order type](create-work-order-types.md).
    - **Price List**: Select a price list from the list or [create a new price list](create-price-list.md).
    - **System Status**: Set to **Unscheduled** by default.
@@ -49,6 +49,8 @@ A work order in Dynamics 365 Field Service can be created from a case using the 
    - The case's **Incident Type** maps to the work order's **Primary Incident Type**.
    - The case's **Description** maps to the work order's **Instructions**.
    - The case's **Functional Location** maps to the work order's **Functional Location**.
+
+   For contact-centered cases, confirm that the resulting work order includes the information your process requires, such as contact, service address, functional location, billing context, and price list. These details can come from the work order or related records when Service Account isn't selected. For more information, go to [Configure service account requirements for work orders](configure-service-account-requirements-work-orders.md).
 
 1. Select **Save** or **Save and Close**.
 

--- a/ce/field-service/create-work-order-types.md
+++ b/ce/field-service/create-work-order-types.md
@@ -1,7 +1,7 @@
 ---
 title: Create a work order type
 description: Create work order types in Dynamics 365 Field Service to categorize and organize your work orders by type.
-ms.date: 06/18/2026
+ms.date: 06/24/2026
 ms.topic: how-to
 author: lmasieri
 ms.author: lmasieri
@@ -18,7 +18,14 @@ Work order types define the general types of work that your organization offers.
   
 1. Choose if an [incident type record](incident-type-overview.md) is required when creating a work order.
 
+1. Choose whether **Service Account** is required for work orders that use this work order type.
+
+    - Require Service Account for work where account-specific context is important, such as service location, billing account, price list, tax settings, service territory, customer assets, entitlements, or work instructions.
+    - Allow work orders without Service Account for work where the service context can come from a contact, internal team, functional location, project, integration, or another process-specific record.
+
 1. Select a [specific price list](create-price-list.md) if you want to use it for this work order type.
+
+    If you allow work orders without Service Account, review how users provide any details that usually come from the account. For example, confirm how the work order gets its service address, billing context, price list, service territory, tax setting, and any account-specific instructions. For more information, go to [Configure service account requirements for work orders](configure-service-account-requirements-work-orders.md).
 
     :::image type="content" source="media/work-order-type-new.png" alt-text="Screenshot of a new Work Order Type in Field Service.":::
 

--- a/ce/field-service/create-work-order.md
+++ b/ce/field-service/create-work-order.md
@@ -15,6 +15,8 @@ A work order in Dynamics 365 Field Service has information on what work needs to
 
 The system determines the work order's location by looking at a manually entered **Service address** first, then the address from the [**Functional location**](functional-locations.md) if set, then the **Service Address** from the account.
 
+The **Service Account** requirement depends on the selected **Work Order Type**. For account-based service processes, Service Account can provide important defaults such as service address, billing account, price list, tax settings, service territory, and work instructions. If the selected Work Order Type allows work orders without Service Account, you can create a work order without selecting an account. In that case, enter the required service, billing, location, and scheduling details directly on the work order or through the related records used by your process.
+
 Once a work order is created, it gets scheduled either manually, with the [schedule assistant](schedule-assistant.md), or the [Resource Scheduling Optimization add-in](rso-overview.md). After the work is complete, a supervisor reviews and approves it.
 
 ## Choose a work order creation method
@@ -51,11 +53,14 @@ You need to have at least one of the following Field Service security roles:
 
 1. At a minimum, enter information in the following required fields.
 
-    - For **Service Account**, select an account from the list or [create a new service account](accounts.md).
+    - For **Service Account**, select an account from the list or [create a new service account](accounts.md) if the selected **Work Order Type** requires one. If the selected Work Order Type allows work orders without Service Account, leave the field blank when the work order uses another service context.
     - For **Work Order Type**, select a work order type from the list or [create a new work order type](create-work-order-types.md).
     - For **System Status**, select **Unscheduled**.
     - For **Price List**, select a price list from list or [create a new price list](create-price-list.md).
     - If [taxes are enabled](set-up-tax-codes.md), choose if the work order is **Taxable** or not. If the work order isn't taxable, work order products and services aren't considered taxable either, regardless of the taxable setting on the product or service.
+
+    > [!TIP]
+    > If you're creating work orders for B2C service, internal maintenance, project-centered work, or another process where service context doesn't always come from an account, ask your Field Service administrator whether the appropriate Work Order Type allows work orders without Service Account. For more information, go to [Configure service account requirements for work orders](configure-service-account-requirements-work-orders.md).
 
 1. Provide optional information for the work order such as service tasks, products, services, or knowledge articles. You can also add this information later.
 

--- a/ce/field-service/field-service-architecture.md
+++ b/ce/field-service/field-service-architecture.md
@@ -1,7 +1,7 @@
 ---
 title: Work order architecture
 description: Understand work order architecture across creation, scheduling, execution, and completion.
-ms.date: 06/18/2026
+ms.date: 06/24/2026
 author: jshotts
 ms.author: jasonshotts
 ms.topic: concept-article
@@ -28,11 +28,11 @@ The following diagram illustrates the entities, attributes, and relationships th
 
 The **Work Order** entity contains the details of the job that needs to be completed, such as work order type, status, duration, and priority.
 
-Work orders are related to an [**Account** entity](accounts.md). Specifying a **Service Account** on the work order adds related account information like territory, address, and service and billing defaults.
+Work orders can be related to an [**Account** entity](accounts.md) through the **Service Account** field. When a Service Account is specified, the work order can use related account information such as service address, territory, billing defaults, tax settings, and work instructions. Administrators can configure whether Service Account is required by Work Order Type, which lets account-based work continue to require an account while other work order types support service context from another source. For more information, go to [Configure service account requirements for work orders](configure-service-account-requirements-work-orders.md).
 
 [**Service Agreements**](set-up-customer-agreements.md) automatically generate recurring work orders. A service agreement can be associated with one service account. That means that all work orders that are generated as part of a service agreement are associated with that service account location. The type of work to be done and assets involved can vary.
 
-[**Customer Assets**](assets.md) are pieces of equipment at the service account location. Work orders that are related to the maintenance, inspection, and repair of a customer asset should correlate to the asset's service account.
+[**Customer Assets**](assets.md) are pieces of equipment associated with a customer or service location. Work orders that are related to the maintenance, inspection, and repair of a customer asset should keep the asset, location, and customer context aligned. In account-based scenarios, that often means correlating the work order to the asset's Service Account. For work order types where Service Account isn't required, use the appropriate asset, functional location, contact, project, or other process-specific fields to preserve service context.
 
 Beyond adding basic details and an account to a work order, you can add **Revenue and Cost** items that better define the specific work to be done. **Work Order Incidents** are a defined package of recommended service tasks, products, services, and characteristics, or skills, that makes creating a work order faster. Instead of manually adding them to a work order, you can add an incident that effectively serves as a template to populate service tasks, products, services, and characteristics.
 

--- a/ce/field-service/finance-operations-integration-create-wo.md
+++ b/ce/field-service/finance-operations-integration-create-wo.md
@@ -1,7 +1,7 @@
 ---
 title: Create a work order using the finance and operations integration
 description: Discover how to create a work order in Dynamics 365 Field Service when using the finance and operations integration.
-ms.date: 10/31/2025
+ms.date: 06/24/2026
 ms.topic: overview
 ms.author: jacoh
 author: jasonccohen
@@ -17,14 +17,18 @@ Once the [finance and operations integration is setup](finance-operations-integr
 
 1. [Create a work order](create-work-order.md) in Field Service and fill in the required fields.
 
-   After you select the **Service Account**, the system filters the finance and operations projects to show projects where the customer and company are relevant to the work order. It also filters the product, service, warehouse, location, and line property fields based on the company of the selected service account.
+   When you create a work order, select or confirm the **Owning Company**. Owning Company is required and identifies the company context used for finance and operations integration.
+
+   Field Service can automatically populate Owning Company based on the selected **Service Account**, **Billing Account**, or **Project**. If you have access to only one company record, Field Service can populate Owning Company from that company.
+
+   The system filters finance and operations projects, products, services, warehouses, locations, and line properties based on the work order's Owning Company. This means work orders can use company-based filtering whether or not the work order has a Service Account.
 
 1. Select a **Finance and Operations project** to align Field Service work orders with finance and operations projects. Once populated, this field can't be changed.
 
    > [!TIP]
    > The **Finance and Operations project** value isn't required until the work order's **System Status** is set to **Posted**. This ensures an organization isn't blocked from creating and conducting work based on whether a relevant project exists for the work order. Once selected, all relevant transactions are automatically synchronized with the selected project regardless of how many are already recorded on the work order.
 
-1. Add the products and services that are needed for the work order and that are relevant to the legal entity of the work order's service account.
+1. Add the products and services that are needed for the work order and that are relevant to the work order's **Owning Company**. For account-based work orders, Owning Company can be populated from the selected Service Account or Billing Account. For project-centered work orders, Owning Company can be populated from the selected Project. For work orders without Service Account, use Owning Company to provide the company context required by the integration.
 
 1. If you use an **Incident Type**, select one that is organized to only include products and services relevant for the company of the work order.
 
@@ -34,6 +38,12 @@ Once the [finance and operations integration is setup](finance-operations-integr
 1. Select **Save**. The system creates a corresponding subproject under the selected finance and operations project. The subproject is the record against which all transactional journals are created.
 
     When products or services are added, journals and journal lines on the subproject for the work order are automatically created.
+
+## Owning Company on agreements
+
+Agreements also include a required **Owning Company** field. Field Service can automatically populate Owning Company on an agreement based on the selected **Service Account** or **Project**. If the user has access to only one company record, Field Service can populate Owning Company from that company.
+
+When an agreement generates work orders, confirm that the agreement's Owning Company and generated work order context align with the company used for finance and operations filtering and transaction synchronization.
 
 ## See also
 

--- a/ce/field-service/index.yml
+++ b/ce/field-service/index.yml
@@ -141,6 +141,8 @@ additionalContent:
       links:
       - url: create-work-order.md
         text: Create a work order
+      - url: configure-service-account-requirements-work-orders.md
+        text: Configure service account requirements
       - url: work-order-status-booking-status.md
         text: Work order life cycle and statuses
       - url: field-service-architecture.md

--- a/ce/field-service/toc.yml
+++ b/ce/field-service/toc.yml
@@ -162,6 +162,8 @@ items:
       href: work-order-experience.md
     - name: Create a new work order
       href: create-work-order.md
+    - name: Configure service account requirements
+      href: configure-service-account-requirements-work-orders.md
     - name: Create a work order from a case
       href: create-work-order-from-case.md
     - name: Create a work order from an agreement


### PR DESCRIPTION
## Summary
- Add a new Field Service article for configuring Service Account requirements by Work Order Type
- Update work order creation, case, agreement, Power Automate, and Dataverse API docs so Service Account is conditionally required
- Update account, architecture, and finance and operations integration docs, including Owning Company-based company filtering for work orders and agreements

## Notes
Drafted from the PM handoff document: service-account-requirements-docs-writer-handoff.md.

## Validation
- Ran `git diff --check`
- Reviewed touched Field Service article diffs for stale Service Account-required language