### PR TITLE
Update create-a-new-report-using-sql-server-data-tools.md

### DIFF
--- a/ce/customerengagement/on-premises/analytics/create-a-new-report-using-sql-server-data-tools.md
+++ b/ce/customerengagement/on-premises/analytics/create-a-new-report-using-sql-server-data-tools.md
@@ -55,7 +55,25 @@ search.audienceType:
   
         Select **Credentials** to specify the credentials to connect to [!INCLUDE[pn_dynamics_crm](../includes/pn-dynamics-crm.md)] apps or [!INCLUDE[pn_CRM_Online](../includes/pn-crm-online.md)] apps, and then select **Next**.  
   
-6. On the **Design the Query** page, type the FetchXML query in the **Query** box. To get this query, you can do one of the following:  
+   > [!IMPORTANT]
+   > The Global Discovery Service reached end of support on June 19, 2026. If your organization isn't listed at sign-in or you can't connect, skip discovery and enter your organization URL directly. Add the following `appSettings` entry to the Visual Studio configuration files listed below, save, and restart Visual Studio:
+   >
+   > ```xml
+   > <appSettings>
+   >   <add key="skipdiscovery" value="true" />
+   > </appSettings>
+   > ```
+   >
+   > - **Visual Studio 2015**
+   >   - `C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\devenv.exe.config`
+   >   - `C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\PrivateAssemblies\PreviewProcessingService.exe.config`
+   > - **Visual Studio 2017 and 2019**
+   >   - `C:\Program Files (x86)\Microsoft Visual Studio\<version>\<edition>\Common7\IDE\devenv.exe.config`
+   >   - `C:\Program Files (x86)\Microsoft Visual Studio\<version>\<edition>\Common7\IDE\CommonExtensions\Microsoft\SSRS\PreviewProcessingService.exe.config`
+   >
+   > If an `<appSettings>` section already exists, add the `<add>` element inside it instead of creating a second section. After you restart Visual Studio, the sign-in dialog prompts you for the organization URL. Enter the full URL, including the region, for example `https://<organization>.crm.dynamics.com`.
+  
+6. On the **Design the Query** page, type the FetchXML query in the **Query** box. To get this query, you can do one of the following:
   
    - Get the FetchXML from an Advanced Find query. To do this, open a Customer Engagement (on-premises) app, select **Advanced Find**, create the query that you want, and then on the **Advanced Find** tab, select **Download Fetch XML**. Copy the FetchXML into the **Query** box of the Dataset Properties in [!INCLUDE[pn_Visual_Studio](../includes/pn-visual-studio.md)].  
   


### PR DESCRIPTION
## Summary
The Global Discovery Service (GDS) reached end of support on June 19, 2026. The Report Authoring Extension relies on GDS to enumerate organizations at sign-in, so customers can now hit "organization not listed / can't connect" errors when creating a Fetch-based report in SQL Server Data Tools.

This adds customer-facing guidance at the sign-in step explaining how to bypass discovery and connect using the organization URL directly.

## Change
- File: `ce/customerengagement/on-premises/analytics/create-a-new-report-using-sql-server-data-tools.md`
- Adds an `[!IMPORTANT]` note under step 5 (Data Source / Credentials) covering:
  - GDS end-of-support date and why sign-in may fail.
  - The `skipdiscovery=true` `<appSettings>` entry, with the Visual Studio config file paths for VS 2015 / 2017 / 2019.
  - Guidance to merge into an existing `<appSettings>` section and to enter the full organization URL, including region, after restarting Visual Studio.