### PR TITLE
Add missing closing tag in customizations.xml example

### DIFF
--- a/ce/sales/custom-sms-localization-admin.md
+++ b/ce/sales/custom-sms-localization-admin.md
@@ -46,6 +46,7 @@ Example of **customizations.xml** including channel definition locales:
             "ChannelMessagePart.Text.Description":  "Text part of SMS"}
     </msdyn_localecontent>
   </msdyn_channeldefinitionlocale>
+ </msdyn_channeldefinitionlocales>
 </ImportExportXml>
 ```
 


### PR DESCRIPTION
## Summary
- `sales/custom-sms-localization-admin.md` has a "customizations.xml" example showing how to define channel definition locales as solution components
- The sample opens `<msdyn_channeldefinitionlocales>` but jumps straight to `</ImportExportXml>` without ever closing it, making the example invalid XML
- Added the missing `</msdyn_channeldefinitionlocales>` closing tag

## Test plan
- [x] Verified the block fails to parse as XML before the fix and parses as well-formed XML after
- [x] One-line addition, no other content changed