### PR TITLE
Add missing </fetch> closing tag in assignment configuration sample

### DIFF
--- a/ce/customer-service/administer/migrate-record-routing-config-using-solutions.md
+++ b/ce/customer-service/administer/migrate-record-routing-config-using-solutions.md
@@ -610,7 +610,8 @@ For sample schema to get all the required records, go to [Sample schema for over
 						</filter>
 					</link-entity>
 				</link-entity>
-			</entity> 
+			</entity>
+		</fetch>
 ```
 
 


### PR DESCRIPTION
## Summary
- `customer-service/administer/migrate-record-routing-config-using-solutions.md` — "Sample 3: Assignment configuration steps for multiple queues without selection criteria" opens `<fetch>` but never closes it; the block ends at `</entity>` with no matching `</fetch>`
- This is unrelated to the "XMLCopy" artifact fixed in #3374 — a separate, pre-existing bug found while re-verifying that fix
- Added the missing `</fetch>` closing tag

## Test plan
- [x] Verified the block fails to parse as XML before the fix and parses as well-formed XML after
- [x] Two-line diff (closing tag added, trailing whitespace on the previous line cleaned up), no other content changed