### PR TITLE
Fix malformed JSON in copilot interaction sample response

### DIFF
--- a/ce/customer-service/develop/download-copilot-transcript-data.md
+++ b/ce/customer-service/develop/download-copilot-transcript-data.md
@@ -121,6 +121,7 @@ The following response indicates a scenario where a representative asks the Copi
 
   ```json
   
+[
 {
             "@odata.etag": "W/\"17413914\"",
             "msdyn_interactiontype": 100230305,
@@ -174,7 +175,8 @@ The following response indicates a scenario where a representative asks the Copi
             "msdyn_copilotinteractionid": "cb9dc43b-9804-f011-bae2-6045bd014292",
             "_createdby_value": "864a96d6-6bb0-ef11-a730-000d3a59065a",
             "timezoneruleversionnumber": 0
-        },
+        }
+]
 
   ```
 ## Download chat transcripts


### PR DESCRIPTION
## Summary
- `customer-service/develop/download-copilot-transcript-data.md` — the "Sample response" under "Get msdyn_copilotinteractionid from copilot event records" shows two interaction records that are the result of querying the `msdyn_copilotevents` collection, but the block was missing the wrapping `[` / `]` array brackets and had a trailing comma after the second object, making it invalid JSON
- Added the missing array brackets and removed the trailing comma

## Test plan
- [x] Verified the block fails to parse as JSON before the fix
- [x] Verified it parses as a valid 2-item JSON array after the fix
- [x] Minimal diff: added `[` before the first object, replaced the trailing `,` after the last object with `]`