### PR TITLE
Clarify work order requirement duration behavior

### DIFF
--- a/ce/field-service/scheduling-requirement-types.md
+++ b/ce/field-service/scheduling-requirement-types.md
@@ -1,7 +1,7 @@
 ---
 title: Requirement types for scheduling
 description: Learn about the different types of resource requirements in Dynamics 365 Field Service and how they drive scheduling.
-ms.date: 05/26/2026
+ms.date: 08/04/2026
 ms.custom: bap-template
 ms.topic: concept-article
 author: mkelleher-msft
@@ -57,6 +57,9 @@ These fields on the resource requirement record determine how the scheduling eng
 When you update a work order, the system automatically updates the related requirement's attributes including name, location, duration, and more. This synchronization ensures the requirement always reflects the latest work order details.
 
 However, if you manually edit a requirement field, that field stops syncing from the work order. Manual edits take precedence.
+
+> [!NOTE]
+> If a work order has no service task or incident type, the work order uses the default booking duration. The related requirement doesn't inherit this default-derived value in its **Duration** field. When the requirement is booked, the system updates only its **Fulfilled Duration** field.
 
 ## Next steps
 

--- a/ce/field-service/scheduling-requirement-types.md
+++ b/ce/field-service/scheduling-requirement-types.md
@@ -59,7 +59,7 @@ When you update a work order, the system automatically updates the related requi
 However, if you manually edit a requirement field, that field stops syncing from the work order. Manual edits take precedence.
 
 > [!NOTE]
-> If a work order has no service task or incident type, the work order uses the default booking duration. The related requirement doesn't inherit this default-derived value in its **Duration** field. When the requirement is booked, the system updates only its **Fulfilled Duration** field.
+> If you don't add a service task or incident type to a work order, the system sets the work order's estimated duration to the default booking duration. The related requirement doesn't inherit this value into its **Duration** field. When the requirement is booked, the system updates only its **Fulfilled Duration** field.
 
 ## Next steps
 

--- a/ce/field-service/universal-resource-scheduling-for-field-service.md
+++ b/ce/field-service/universal-resource-scheduling-for-field-service.md
@@ -45,7 +45,7 @@ By default, the system creates one requirement for each work order. However, a w
 Requirements inherit attributes from the work order, such as name, location, duration, and more. Updating work order attributes updates requirement attributes. Manual edits to requirements can be made before scheduling, too.
 
 > [!NOTE]
-> If a work order has no service task or incident type, the work order uses the default booking duration. The related requirement doesn't inherit this default-derived value in its **Duration** field. When the requirement is booked, the system updates only its **Fulfilled Duration** field.
+> If you don't add a service task or incident type to a work order, the system sets the work order's estimated duration to the default booking duration. The related requirement doesn't inherit this value into its **Duration** field. When the requirement is booked, the system updates only its **Fulfilled Duration** field.
 
 > [!CAUTION]
 > Manually created requirements for work order don't synchronize automatically.

--- a/ce/field-service/universal-resource-scheduling-for-field-service.md
+++ b/ce/field-service/universal-resource-scheduling-for-field-service.md
@@ -1,7 +1,7 @@
 ---
 title: Universal Resource Scheduling for Dynamics 365 Field Service overview
 description: Learn all about Universal Resource Scheduling for Dynamics 365 Field Service
-ms.date: 02/19/2026
+ms.date: 08/04/2026
 ms.custom: bap-template
 ms.topic: overview
 author: mkelleher-msft
@@ -43,6 +43,9 @@ For every work order, the system creates a related requirement. It outlines the 
 By default, the system creates one requirement for each work order. However, a work order can have multiple requirements or a requirement group with multiple requirements. [Create incident types to configure templates for work order](configure-incident-types.md).
 
 Requirements inherit attributes from the work order, such as name, location, duration, and more. Updating work order attributes updates requirement attributes. Manual edits to requirements can be made before scheduling, too.
+
+> [!NOTE]
+> If a work order has no service task or incident type, the work order uses the default booking duration. The related requirement doesn't inherit this default-derived value in its **Duration** field. When the requirement is booked, the system updates only its **Fulfilled Duration** field.
 
 > [!CAUTION]
 > Manually created requirements for work order don't synchronize automatically.


### PR DESCRIPTION
Clarifies Field Service behavior when a work order has no service task or incident type. Although the work order uses the default booking duration, its related resource requirement doesn't inherit that value into **Duration**.


Adds notes explaining that after booking, only the requirement's **Fulfilled Duration** is updated. This prevents the existing duration-inheritance guidance from implying unsupported behavior.