### PR TITLE
Fix PowerShell formatting errors in SSS on-prem EXO documentation

### DIFF
--- a/ce/customerengagement/on-premises/admin/connect-dynamics-365-on-premises-exchange-online.md
+++ b/ce/customerengagement/on-premises/admin/connect-dynamics-365-on-premises-exchange-online.md
@@ -101,11 +101,10 @@ Before you configure Dynamics 365 Customer Engagement (on-premises) and Exchange
 
     [Download](https://github.com/microsoft/PowerApps-Samples/blob/master/powershell/ServerSideSync/ConfigureCrmServerSideSync.ps1) the script and replace the existing script if the ConfigureCrmServerSideSync.ps1 script present in the current powershell session directory, from above, is different than the script in the download link:
 
-     $ConfigureCrmServerSideSyncWithCommand = ".\ConfigureCrmServerSideSync.ps1 -privateKeyPassword (ConvertTo- 
-     SecureString 'personal_certfile_password' -AsPlainText -Force) -pfxFilePath c:\Personalcertfile.pfx -organizationName 
-     organization_name -microsoftEntraIdTenantIdOrDomainName microsoft_entraid_tenantid_or_domain_name -ClientID 
-     app_id_from_step3 -ClientSecret -client_secret" 
-     Invoke-Expression -command $ConfigureCrmServerSideSyncWithCommand 
+    ```powershell
+    $ConfigureCrmServerSideSyncWithCommand = ".\ConfigureCrmServerSideSync.ps1 -privateKeyPassword (ConvertTo-SecureString 'personal_certfile_password' -AsPlainText -Force) -pfxFilePath c:\Personalcertfile.pfx -organizationName organization_name -microsoftEntraIdTenantIdOrDomainName microsoft_entraid_tenantid_or_domain_name -ClientID app_id_from_step2 -ClientSecret client_secret"
+    Invoke-Expression -Command $ConfigureCrmServerSideSyncWithCommand 
+    ```
 
 > [!IMPORTANT]
 > For customers using Exchange Online with Government Community Cloud (GCC) High for US government environments, the **S2SDefaultAuthorizationServerMetadataUrl** in the PowerShell script must be changed to *https://login.microsoftonline.us/metadata/json/1*.


### PR DESCRIPTION
This pull request updates the documentation for configuring Dynamics 365 Customer Engagement (on-premises) with Exchange Online. The main change is an improvement to the PowerShell script example to clarify usage and correct a parameter reference.

**Script and documentation improvements:**

* Updated the PowerShell script example to use markdown code block formatting for better readability.
* Corrected the `-ClientID` parameter in the script example to reference `app_id_from_step2` instead of `app_id_from_step3`, ensuring the instructions match the correct setup step.
* Fixed the casing of the `-Command` parameter in the `Invoke-Expression` call for consistency and accuracy.